### PR TITLE
Fix color comparison logic

### DIFF
--- a/src/example/example/rgbd_function/object_classification.py
+++ b/src/example/example/rgbd_function/object_classification.py
@@ -637,7 +637,7 @@ class ObjectClassificationNode(Node):
     def color_comparison(self, rgb):
         if rgb[0] > rgb[1] and rgb[0] > rgb[2]:
             return 'red'
-        elif rgb[2] > rgb[1] and rgb[2] > rgb[1]:
+        elif rgb[2] > rgb[1] and rgb[2] > rgb[0]:
             return 'blue'
         else:
             return None


### PR DESCRIPTION
## Summary
- fix logic for detecting blue in `color_comparison`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ament_copyright')*

------
https://chatgpt.com/codex/tasks/task_e_68454f2553f88326b33edbac7a644223